### PR TITLE
Add header-based schema id scenarios (Avro, protobuf, json), bump to Confluent Platform 8.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,13 +16,15 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
 
-    <confluent-platform.version>7.2.1</confluent-platform.version>
+    <!-- 8.0+ is required for schema id in header support (guid wire format), see
+         https://github.com/gklijs/schema_registry_converter/issues/139 -->
+    <confluent-platform.version>8.3.1</confluent-platform.version>
 
     <avro-maven-plugin.version>1.11.1</avro-maven-plugin.version>
     <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
     <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>
     <protobuf-maven.version>0.6.1</protobuf-maven.version>
-    <apache-kafka.version>5.3.0-ccs</apache-kafka.version>
+    <apache-kafka.version>8.3.1-ccs</apache-kafka.version>
 
     <schema-registry-url>http://127.0.0.1:8081</schema-registry-url>
   </properties>
@@ -97,6 +99,7 @@
           <subjects>
             <avro-result>src/main/avro/result.avsc</avro-result>
             <testavro-value>src/main/avro/schemas.avsc</testavro-value>
+            <testavroheader-value>src/main/avro/schemas.avsc</testavroheader-value>
             <result.proto>src/main/proto/result.proto</result.proto>
             <testproto-value>src/main/proto/test.proto</testproto-value>
             <result.json>src/main/json/result.json</result.json>
@@ -106,6 +109,7 @@
           <schemaTypes>
             <avro-result>AVRO</avro-result>
             <testavro-value>AVRO</testavro-value>
+            <testavroheader-value>AVRO</testavroheader-value>
             <result.proto>PROTOBUF</result.proto>
             <testproto-value>PROTOBUF</testproto-value>
             <result.json>JSON</result.json>
@@ -119,6 +123,12 @@
                 <subject>avro-result</subject>
               </reference>
             </testavro-value>
+            <testavroheader-value>
+              <reference>
+                <name>org.schema_registry_test_app.avro.Result</name>
+                <subject>avro-result</subject>
+              </reference>
+            </testavroheader-value>
             <testproto-value>
               <reference>
                 <name>result.proto</name>

--- a/pom.xml
+++ b/pom.xml
@@ -102,8 +102,10 @@
             <testavroheader-value>src/main/avro/schemas.avsc</testavroheader-value>
             <result.proto>src/main/proto/result.proto</result.proto>
             <testproto-value>src/main/proto/test.proto</testproto-value>
+            <testprotoheader-value>src/main/proto/test.proto</testprotoheader-value>
             <result.json>src/main/json/result.json</result.json>
             <testjson-value>src/main/json/jsontest.json</testjson-value>
+            <testjsonheader-value>src/main/json/jsontest.json</testjsonheader-value>
             <testgoogle-value>src/main/proto/google.proto</testgoogle-value>
           </subjects>
           <schemaTypes>
@@ -112,8 +114,10 @@
             <testavroheader-value>AVRO</testavroheader-value>
             <result.proto>PROTOBUF</result.proto>
             <testproto-value>PROTOBUF</testproto-value>
+            <testprotoheader-value>PROTOBUF</testprotoheader-value>
             <result.json>JSON</result.json>
             <testjson-value>JSON</testjson-value>
+            <testjsonheader-value>JSON</testjsonheader-value>
             <testgoogle-value>PROTOBUF</testgoogle-value>
           </schemaTypes>
           <references>
@@ -135,12 +139,24 @@
                 <subject>result.proto</subject>
               </reference>
             </testproto-value>
+            <testprotoheader-value>
+              <reference>
+                <name>result.proto</name>
+                <subject>result.proto</subject>
+              </reference>
+            </testprotoheader-value>
             <testjson-value>
               <reference>
                 <name>result.json</name>
                 <subject>result.json</subject>
               </reference>
             </testjson-value>
+            <testjsonheader-value>
+              <reference>
+                <name>result.json</name>
+                <subject>result.json</subject>
+              </reference>
+            </testjsonheader-value>
           </references>
           <compatibilityLevels/>
           <previousSchemaPaths/>

--- a/src/main/java/org/schema_registry_test_app/App.java
+++ b/src/main/java/org/schema_registry_test_app/App.java
@@ -26,8 +26,10 @@ public class App {
             TestAvro.produceOne();
             TestAvro.produceOneWithHeaderId();
             TestProto.produceOne();
+            TestProto.produceOneWithHeaderId();
             TestGoogle.produceOne();
             TestJson.produceOne();
+            TestJson.produceOneWithHeaderId();
         } catch (ExecutionException | InterruptedException e) {
             LOGGER.error("Some error occurred", e);
             Thread.currentThread().interrupt();

--- a/src/main/java/org/schema_registry_test_app/App.java
+++ b/src/main/java/org/schema_registry_test_app/App.java
@@ -24,6 +24,7 @@ public class App {
         final long start = System.currentTimeMillis();
         try {
             TestAvro.produceOne();
+            TestAvro.produceOneWithHeaderId();
             TestProto.produceOne();
             TestGoogle.produceOne();
             TestJson.produceOne();

--- a/src/main/java/org/schema_registry_test_app/Utils.java
+++ b/src/main/java/org/schema_registry_test_app/Utils.java
@@ -30,6 +30,8 @@ public class Utils {
     // Confluent Schema Registry 8.0+ guid. See
     // https://github.com/gklijs/schema_registry_converter/issues/139.
     public static final String TEST_TOPIC_AVRO_HEADER = "testavroheader";
+    public static final String TEST_TOPIC_PROTO_HEADER = "testprotoheader";
+    public static final String TEST_TOPIC_JSON_HEADER = "testjsonheader";
     public static final String SCHEMA_REGISTRY_URL = getSchemaRegistryUrl();
     public static final String BOOTSTRAP_SERVERS = getBootstrapServers();
 

--- a/src/main/java/org/schema_registry_test_app/Utils.java
+++ b/src/main/java/org/schema_registry_test_app/Utils.java
@@ -2,6 +2,7 @@ package org.schema_registry_test_app;
 
 import com.google.protobuf.GeneratedMessageV3;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+import io.confluent.kafka.serializers.schema.id.HeaderSchemaIdSerializer;
 import org.apache.avro.specific.SpecificRecord;
 import org.apache.kafka.clients.producer.*;
 import org.apache.kafka.common.serialization.Serializer;
@@ -25,6 +26,10 @@ public class Utils {
     public static final String TEST_TOPIC_PROTO = "testproto";
     public static final String TEST_TOPIC_GOOGLE = "testgoogle";
     public static final String TEST_TOPIC_JSON = "testjson";
+    // Schema id carried in a __value_schema_id header instead of the payload prefix, using a
+    // Confluent Schema Registry 8.0+ guid. See
+    // https://github.com/gklijs/schema_registry_converter/issues/139.
+    public static final String TEST_TOPIC_AVRO_HEADER = "testavroheader";
     public static final String SCHEMA_REGISTRY_URL = getSchemaRegistryUrl();
     public static final String BOOTSTRAP_SERVERS = getBootstrapServers();
 
@@ -73,6 +78,23 @@ public class Utils {
         }
     }
 
+    /**
+     * Like {@link #produceOne(Object, Class, String)}, but configures the value serializer to
+     * put the schema id/guid in a {@code __value_schema_id} header instead of the usual payload
+     * prefix, via {@link HeaderSchemaIdSerializer}. Requires a schema registry that returns a
+     * guid (Confluent Schema Registry 8.0+). See
+     * https://github.com/gklijs/schema_registry_converter/issues/139.
+     */
+    public static <T extends O, O, S extends Serializer<O>> void produceOneWithHeaderId(T item, Class<S> serializerClass,
+                                                                                          String topic) throws ExecutionException, InterruptedException {
+        try (Producer<String, T> producer = new KafkaProducer<>(producerPropertiesWithHeaderId(serializerClass))) {
+            var record = new ProducerRecord<>(topic, TEST_KEY, item);
+            RecordMetadata recordMetadata = producer.send(record).get();
+            LOGGER.info("Produced test message with offset {} and value size {} to topic {} using header schema id",
+                    recordMetadata.offset(), recordMetadata.serializedValueSize(), topic);
+        }
+    }
+
     private static <O, S extends Serializer<O>> Properties producerProperties(Class<S> serializerClass) {
         Properties props = new Properties();
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
@@ -81,6 +103,12 @@ public class Utils {
         props.put(AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS, false);
         props.put(AbstractKafkaSchemaSerDeConfig.USE_LATEST_VERSION, true);
         props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, SCHEMA_REGISTRY_URL);
+        return props;
+    }
+
+    private static <O, S extends Serializer<O>> Properties producerPropertiesWithHeaderId(Class<S> serializerClass) {
+        Properties props = producerProperties(serializerClass);
+        props.put(AbstractKafkaSchemaSerDeConfig.VALUE_SCHEMA_ID_SERIALIZER, HeaderSchemaIdSerializer.class.getName());
         return props;
     }
 }

--- a/src/main/java/org/schema_registry_test_app/avro/TestAvro.java
+++ b/src/main/java/org/schema_registry_test_app/avro/TestAvro.java
@@ -29,4 +29,8 @@ public class TestAvro {
     public static void produceOne() throws ExecutionException, InterruptedException {
         Utils.produceOne(testValue(), KafkaAvroSerializer.class);
     }
+
+    public static void produceOneWithHeaderId() throws ExecutionException, InterruptedException {
+        Utils.produceOneWithHeaderId(testValue(), KafkaAvroSerializer.class, Utils.TEST_TOPIC_AVRO_HEADER);
+    }
 }

--- a/src/main/java/org/schema_registry_test_app/json/TestJson.java
+++ b/src/main/java/org/schema_registry_test_app/json/TestJson.java
@@ -42,4 +42,9 @@ public class TestJson {
     public static void produceOne() throws ExecutionException, InterruptedException {
         Utils.produceOne(testValue(), KafkaJsonSchemaSerializer.class);
     }
+
+    @SuppressWarnings("unchecked")
+    public static void produceOneWithHeaderId() throws ExecutionException, InterruptedException {
+        Utils.produceOneWithHeaderId(testValue(), KafkaJsonSchemaSerializer.class, Utils.TEST_TOPIC_JSON_HEADER);
+    }
 }

--- a/src/main/java/org/schema_registry_test_app/proto/TestProto.java
+++ b/src/main/java/org/schema_registry_test_app/proto/TestProto.java
@@ -29,4 +29,9 @@ public class TestProto {
     public static void produceOne() throws ExecutionException, InterruptedException {
         Utils.produceOne(testValue(), KafkaProtobufSerializer.class);
     }
+
+    @SuppressWarnings("unchecked")
+    public static void produceOneWithHeaderId() throws ExecutionException, InterruptedException {
+        Utils.produceOneWithHeaderId(testValue(), KafkaProtobufSerializer.class, Utils.TEST_TOPIC_PROTO_HEADER);
+    }
 }


### PR DESCRIPTION
## What

Produces extra messages using `HeaderSchemaIdSerializer` (the schema id/guid goes in a `__key_schema_id`/`__value_schema_id` header instead of the payload prefix), for all three schema types, so consumers can be tested against real Confluent-produced headers. Written for gklijs/schema_registry_converter#139, which added a matching `decode_with_header_id` to the Rust crate.

- `confluent-platform.version` 7.2.1 → 8.3.1 (required: guids/header mode need Confluent Schema Registry 8.0+)
- `apache-kafka.version` bumped to the matching `8.3.1-ccs` client
- New topics/subjects, each reusing the existing non-header schema/references:
  - `testavroheader` (Avro, `KafkaAvroSerializer` + `TestAvro.produceOneWithHeaderId`)
  - `testprotoheader` (Protobuf, `KafkaProtobufSerializer` + `TestProto.produceOneWithHeaderId`)
  - `testjsonheader` (JSON Schema, `KafkaJsonSchemaSerializer` + `TestJson.produceOneWithHeaderId`)
- All three called from `App.main` alongside the existing prefix-mode scenarios
- `Utils.produceOneWithHeaderId` sets `value.schema.id.serializer` to `HeaderSchemaIdSerializer`; everything else (topic creation, key handling) matches the existing `produceOne` path

## Verified

- `mvn compile` succeeds against Confluent Platform 8.3.1 for all three (confirms `HeaderSchemaIdSerializer` and `AbstractKafkaSchemaSerDeConfig.VALUE_SCHEMA_ID_SERIALIZER` resolve correctly against the real 8.3.1 jars, for each serializer).
- **Not yet run end-to-end** against a live broker/schema registry/Rust consumer — no Docker access in the environment this was written in.

## Still needed before this is fully wired up

`schema_registry_converter`'s `docker-compose.yaml` has already been moved to KRaft mode (Confluent stopped publishing `cp-zookeeper` images for CP 8.x) and bumped to CP 8.3.1, and a Rust integration test for the Avro case (`test5_test_avro_header_id_from_java_test_app`) has been written there. Still needed: matching Rust integration tests for the proto/json header cases, and an actual live end-to-end run (docker compose up + `cargo test --all-features`) once this image is rebuilt and pushed. Tracked in gklijs/schema_registry_converter#139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
